### PR TITLE
add provides section for latest panda (S11 support)

### DIFF
--- a/META.info
+++ b/META.info
@@ -2,6 +2,9 @@
     "name" : "Games::BubbleBreaker",
     "version" : "*",
     "description" : "A mouse based logic game",
+    "provides": {
+        "Games::BubbleBreaker6": "lib/Games/BubbleBreaker.pm6"
+    },
     "depends" : [ "SDL" ],
     "source-url" : "git://github.com/FROGGS/p6-Games-BubbleBreaker.git"
 }


### PR DESCRIPTION
I wasn't sure what to do with "bin/bubble-breaker.p6" and I came to conclusion that it doesn't need to be in "provides"... Dunno 100% though
