### PR TITLE
Fix filename extension of bubble-breaker program

### DIFF
--- a/README
+++ b/README
@@ -2,4 +2,4 @@ NAME
     Games::BubbleBreaker - a mouse based logic game
 
 RUN
-    perl6 bin/bubble-breaker.pm6
+    perl6 bin/bubble-breaker.p6

--- a/t/00-run.t
+++ b/t/00-run.t
@@ -7,9 +7,9 @@ use Test::Most 'bail';
 my $time                   = Time::HiRes::time;
 $ENV{'BUBBLEBREAKER_TEST'} = 1;
 
-ok( -e 'bin/bubble-breaker.pl',             'bin/bubble-breaker.pl exists' );
+ok( -e 'bin/bubble-breaker.p6',             'bin/bubble-breaker.p6 exists' );
 is( system("$^X -e 1"),                  0, "we can execute perl as $^X" );
-my ($stdout, $stderr) = Capture::Tiny::capture { system("$^X bin/bubble-breaker.pl") };
+my ($stdout, $stderr) = Capture::Tiny::capture { system("$^X bin/bubble-breaker.p6") };
 ok( !$stderr, 'bubble-breaker ran ' . (Time::HiRes::time - $time) . ' seconds' );
 
 $stdout ||= '';


### PR DESCRIPTION
The filename extension is supposed to be `.p6`, however was `.pl` in the
tests and `.pm6` in the readme.  This change corrects these issues.
